### PR TITLE
Show counts on /tags page

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -4,10 +4,11 @@ import IconHash from "@/assets/icons/IconHash.svg";
 export interface Props {
   tag: string;
   tagName: string;
+  count?: number;
   size?: "sm" | "lg";
 }
 
-const { tag, tagName, size = "sm" } = Astro.props;
+const { tag, tagName, count, size = "sm" } = Astro.props;
 ---
 
 <li
@@ -31,6 +32,9 @@ const { tag, tagName, size = "sm" } = Astro.props;
         { "-mr-5 size-6": size === "lg" },
       ]}
     />
-    &nbsp;<span>{tagName}</span>
+    &nbsp;<span>
+      {tagName}
+      {count !== undefined && ` (${count})`}
+    </span>
   </a>
 </li>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -17,7 +17,9 @@ let tags = getUniqueTags(posts);
   <Header />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
-      {tags.map(({ tag, tagName }) => <Tag {tag} {tagName} size="lg" />)}
+      {tags.map(({ tag, tagName, count }) => (
+        <Tag {tag} {tagName} {count} size="lg" />
+      ))}
     </ul>
   </Main>
   <Footer />

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -5,18 +5,31 @@ import postFilter from "./postFilter";
 interface Tag {
   tag: string;
   tagName: string;
+  count: number;
 }
 
 const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
-  const tags: Tag[] = posts
+  const tagMap = new Map<string, { tagName: string; count: number }>();
+
+  posts
     .filter(postFilter)
     .flatMap(post => post.data.tags)
-    .map(tag => ({ tag: slugifyStr(tag), tagName: tag }))
-    .filter(
-      (value, index, self) =>
-        self.findIndex(tag => tag.tag === value.tag) === index
-    )
-    .sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
+    .forEach(tagName => {
+      const slug = slugifyStr(tagName);
+      const existing = tagMap.get(slug);
+      if (existing) {
+        existing.count++;
+      } else {
+        tagMap.set(slug, { tagName, count: 1 });
+      }
+    });
+
+  const tags: Tag[] = Array.from(tagMap, ([tag, { tagName, count }]) => ({
+    tag,
+    tagName,
+    count,
+  })).sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
+
   return tags;
 };
 


### PR DESCRIPTION
## Summary
- show counts of each tag on the tag index page
- extend `getUniqueTags` utility to compute tag frequencies
- allow Tag component to optionally display counts

## Testing
- `pnpm lint`
- `pnpm build` *(fails: getaddrinfo ENOTFOUND fonts.googleapis.com)*