### PR TITLE
Show tag counts in tags page

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -5,9 +5,10 @@ export interface Props {
   tag: string;
   tagName: string;
   size?: "sm" | "lg";
+  count?: number;
 }
 
-const { tag, tagName, size = "sm" } = Astro.props;
+const { tag, tagName, size = "sm", count } = Astro.props;
 ---
 
 <li
@@ -32,5 +33,6 @@ const { tag, tagName, size = "sm" } = Astro.props;
       ]}
     />
     &nbsp;<span>{tagName}</span>
+    {typeof count === "number" && <sup class="text-xs">{count}</sup>}
   </a>
 </li>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -17,7 +17,11 @@ let tags = getUniqueTags(posts);
   <Header />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
-      {tags.map(({ tag, tagName }) => <Tag {tag} {tagName} size="lg" />)}
+      {
+        tags.map(({ tag, tagName, count }) => (
+          <Tag {tag} {tagName} count={count} size="lg" />
+        ))
+      }
     </ul>
   </Main>
   <Footer />

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -5,19 +5,25 @@ import postFilter from "./postFilter";
 interface Tag {
   tag: string;
   tagName: string;
+  count: number;
 }
 
 const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
-  const tags: Tag[] = posts
+  const tagMap: Record<string, Tag> = {};
+
+  posts
     .filter(postFilter)
     .flatMap(post => post.data.tags)
-    .map(tag => ({ tag: slugifyStr(tag), tagName: tag }))
-    .filter(
-      (value, index, self) =>
-        self.findIndex(tag => tag.tag === value.tag) === index
-    )
-    .sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
-  return tags;
+    .forEach(tag => {
+      const slug = slugifyStr(tag);
+      if (tagMap[slug]) {
+        tagMap[slug].count += 1;
+      } else {
+        tagMap[slug] = { tag: slug, tagName: tag, count: 1 };
+      }
+    });
+
+  return Object.values(tagMap).sort((a, b) => a.tag.localeCompare(b.tag));
 };
 
 export default getUniqueTags;


### PR DESCRIPTION
## Summary
- count how many posts use each tag
- display the count in the tag list

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build` *(fails: getaddrinfo ENOTFOUND fonts.googleapis.com)*