### PR TITLE
Show tag post counts

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -4,10 +4,11 @@ import IconHash from "@/assets/icons/IconHash.svg";
 export interface Props {
   tag: string;
   tagName: string;
+  count?: number;
   size?: "sm" | "lg";
 }
 
-const { tag, tagName, size = "sm" } = Astro.props;
+const { tag, tagName, count, size = "sm" } = Astro.props;
 ---
 
 <li
@@ -32,5 +33,8 @@ const { tag, tagName, size = "sm" } = Astro.props;
       ]}
     />
     &nbsp;<span>{tagName}</span>
+    {count !== undefined && (
+      <span class="ml-1 text-sm opacity-70">({count})</span>
+    )}
   </a>
 </li>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -17,7 +17,9 @@ let tags = getUniqueTags(posts);
   <Header />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
-      {tags.map(({ tag, tagName }) => <Tag {tag} {tagName} size="lg" />)}
+      {tags.map(({ tag, tagName, count }) => (
+        <Tag {tag} {tagName} count={count} size="lg" />
+      ))}
     </ul>
   </Main>
   <Footer />

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -5,18 +5,29 @@ import postFilter from "./postFilter";
 interface Tag {
   tag: string;
   tagName: string;
+  count: number;
 }
 
 const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
-  const tags: Tag[] = posts
+  const tagMap = new Map<string, { tagName: string; count: number }>();
+
+  posts
     .filter(postFilter)
     .flatMap(post => post.data.tags)
-    .map(tag => ({ tag: slugifyStr(tag), tagName: tag }))
-    .filter(
-      (value, index, self) =>
-        self.findIndex(tag => tag.tag === value.tag) === index
-    )
+    .forEach(tagName => {
+      const tag = slugifyStr(tagName);
+      const entry = tagMap.get(tag);
+      if (entry) {
+        entry.count += 1;
+      } else {
+        tagMap.set(tag, { tagName, count: 1 });
+      }
+    });
+
+  const tags: Tag[] = Array.from(tagMap.entries())
+    .map(([tag, { tagName, count }]) => ({ tag, tagName, count }))
     .sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
+
   return tags;
 };
 


### PR DESCRIPTION
## Summary
- add count property to getUniqueTags utility
- display count in Tag component when provided
- pass tag count to Tag elements on tags index page

## Testing
- `pnpm format` *(fails: Cannot find package 'prettier-plugin-astro')*
- `pnpm lint` *(fails: Cannot find package 'eslint-plugin-astro')*
- `pnpm build` *(fails: astro: not found)*