### PR TITLE
Refactor fallback font loader

### DIFF
--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -1,3 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+async function loadSystemFont(weight: number): Promise<ArrayBuffer> {
+  const file = weight === 700 ? "DejaVuSans-Bold.ttf" : "DejaVuSans.ttf";
+  const buf = await readFile(join("/usr/share/fonts/truetype/dejavu", file));
+  return buf.buffer.slice(
+    buf.byteOffset,
+    buf.byteOffset + buf.byteLength
+  ) as ArrayBuffer;
+}
+
+async function fetchCSS(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
+      },
+    });
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchFont(url: string): Promise<ArrayBuffer | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error();
+    return res.arrayBuffer();
+  } catch {
+    return null;
+  }
+}
+
 async function loadGoogleFont(
   font: string,
   text: string,
@@ -5,14 +41,8 @@ async function loadGoogleFont(
 ): Promise<ArrayBuffer> {
   const API = `https://fonts.googleapis.com/css2?family=${font}:wght@${weight}&text=${encodeURIComponent(text)}`;
 
-  const css = await (
-    await fetch(API, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
-      },
-    })
-  ).text();
+  const css = await fetchCSS(API);
+  if (!css) return loadSystemFont(weight);
 
   const resource = css.match(
     /src: url\((.+?)\) format\('(opentype|truetype)'\)/
@@ -20,13 +50,9 @@ async function loadGoogleFont(
 
   if (!resource) throw new Error("Failed to download dynamic font");
 
-  const res = await fetch(resource[1]);
-
-  if (!res.ok) {
-    throw new Error("Failed to download dynamic font. Status: " + res.status);
-  }
-
-  return res.arrayBuffer();
+  const data = await fetchFont(resource[1]);
+  if (data) return data;
+  return loadSystemFont(weight);
 }
 
 async function loadGoogleFonts(


### PR DESCRIPTION
## Summary
- reorganize font loading helpers
- use system fonts if Google Fonts are unavailable

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6850e57bf40c832a93835dc57db23e88