### PR TITLE
Fix path normalization for related posts

### DIFF
--- a/src/utils/transformers/transformers.ts
+++ b/src/utils/transformers/transformers.ts
@@ -88,7 +88,7 @@ async function processFile(filePath: string): Promise<Document | null> {
     if (!data.slug || data.draft) return null;
     const plain = await getPlainText(content);
     return {
-      path: toPosix(filePath),
+      path: toPosix(path.relative(process.cwd(), filePath)),
       content: plain,
       frontmatter: data as Frontmatter,
     };


### PR DESCRIPTION
## Summary
- normalize document paths using `path.relative` in the transformer utility

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `pnpm generate:related` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685e46f3382c832ab6104b2703551c77