### PR TITLE
Add responsive box layout for related posts

### DIFF
--- a/src/assets/similarities.json
+++ b/src/assets/similarities.json
@@ -4,7 +4,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-09-30T15:57:52.737Z",
       "title": "AWS Certified Security - Specialty（SCS-C02）合格体験記",
-      "slug": "SCS-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -12,6 +11,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Security - Specialty（SCS-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "SCS-C02-pass-experience",
       "path": "src/data/blog/_2024/SCS-C02-pass-experience.md",
       "similarity": 1
     },
@@ -19,7 +19,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -27,6 +26,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.85
     },
@@ -34,7 +34,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-03-29T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -42,6 +41,7 @@
         "資格取得"
       ],
       "description": "AWS Certified Data Analytics - Specialty（DAS-C01）試験に合格しましたので、その体験をシェアします。",
+      "slug": "DVA-C02-pass-experience",
       "path": "src/data/blog/_2023/DVA-C02-pass-experience.md",
       "similarity": 0.85
     },
@@ -49,7 +49,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-10-02T15:57:52.737Z",
       "title": "AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記",
-      "slug": "SOA-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -57,6 +56,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified SysOps Administrator - Associate（SOA-C02）試験に無事合格できましたので、その体験を共有します。",
+      "slug": "SOA-C02-pass-experience",
       "path": "src/data/blog/_2023/SOA-C02-pass-experience.md",
       "similarity": 0.81
     },
@@ -64,14 +64,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.75
     }
@@ -81,7 +80,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -89,6 +87,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 1
     },
@@ -96,7 +95,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -104,6 +102,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.85
     },
@@ -111,7 +110,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-03-29T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -119,6 +117,7 @@
         "資格取得"
       ],
       "description": "AWS Certified Data Analytics - Specialty（DAS-C01）試験に合格しましたので、その体験をシェアします。",
+      "slug": "DVA-C02-pass-experience",
       "path": "src/data/blog/_2023/DVA-C02-pass-experience.md",
       "similarity": 0.85
     },
@@ -126,7 +125,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-10-02T15:57:52.737Z",
       "title": "AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記",
-      "slug": "SOA-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -134,6 +132,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified SysOps Administrator - Associate（SOA-C02）試験に無事合格できましたので、その体験を共有します。",
+      "slug": "SOA-C02-pass-experience",
       "path": "src/data/blog/_2023/SOA-C02-pass-experience.md",
       "similarity": 0.81
     },
@@ -141,14 +140,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.75
     }
@@ -158,14 +156,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.95
     },
@@ -173,7 +170,6 @@
       "author": "Devkey",
       "pubDatetime": "2022-09-29T15:57:52.737Z",
       "title": "AWS Certified Solutions Architect - Associate (SAA-C03) 合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -181,6 +177,7 @@
       ],
       "category": "資格取得",
       "description": "先日 AWS Certified Solutions Architect – Associate（SAA-C03）を受験したので、情報共有します。2022年9月に SAA-C02 から SAA-C03 へ試験が切り替わったため、新試験の特徴を共有します。",
+      "slug": "SAA-C03-pass-experience",
       "path": "src/data/blog/_2022/SAA-C03-pass-experience.md",
       "similarity": 0.92
     },
@@ -188,7 +185,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -196,6 +192,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.75
     },
@@ -203,7 +200,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -211,6 +207,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 0.73
     },
@@ -218,7 +215,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-09-30T15:57:52.737Z",
       "title": "AWS Certified Security - Specialty（SCS-C02）合格体験記",
-      "slug": "SCS-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -226,6 +222,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Security - Specialty（SCS-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "SCS-C02-pass-experience",
       "path": "src/data/blog/_2024/SCS-C02-pass-experience.md",
       "similarity": 0.73
     }
@@ -235,7 +232,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -243,6 +239,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.95
     },
@@ -250,7 +247,6 @@
       "author": "Devkey",
       "pubDatetime": "2022-09-29T15:57:52.737Z",
       "title": "AWS Certified Solutions Architect - Associate (SAA-C03) 合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -258,6 +254,7 @@
       ],
       "category": "資格取得",
       "description": "先日 AWS Certified Solutions Architect – Associate（SAA-C03）を受験したので、情報共有します。2022年9月に SAA-C02 から SAA-C03 へ試験が切り替わったため、新試験の特徴を共有します。",
+      "slug": "SAA-C03-pass-experience",
       "path": "src/data/blog/_2022/SAA-C03-pass-experience.md",
       "similarity": 0.94
     },
@@ -265,7 +262,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -273,6 +269,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.77
     },
@@ -280,7 +277,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-10-02T15:57:52.737Z",
       "title": "AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記",
-      "slug": "SOA-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -288,6 +284,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified SysOps Administrator - Associate（SOA-C02）試験に無事合格できましたので、その体験を共有します。",
+      "slug": "SOA-C02-pass-experience",
       "path": "src/data/blog/_2023/SOA-C02-pass-experience.md",
       "similarity": 0.76
     },
@@ -295,7 +292,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -303,6 +299,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 0.75
     }
@@ -312,7 +309,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -320,6 +316,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 0.85
     },
@@ -327,7 +324,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-09-30T15:57:52.737Z",
       "title": "AWS Certified Security - Specialty（SCS-C02）合格体験記",
-      "slug": "SCS-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -335,6 +331,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Security - Specialty（SCS-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "SCS-C02-pass-experience",
       "path": "src/data/blog/_2024/SCS-C02-pass-experience.md",
       "similarity": 0.85
     },
@@ -342,7 +339,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-10-02T15:57:52.737Z",
       "title": "AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記",
-      "slug": "SOA-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -350,6 +346,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified SysOps Administrator - Associate（SOA-C02）試験に無事合格できましたので、その体験を共有します。",
+      "slug": "SOA-C02-pass-experience",
       "path": "src/data/blog/_2023/SOA-C02-pass-experience.md",
       "similarity": 0.8
     },
@@ -357,7 +354,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-03-29T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -365,6 +361,7 @@
         "資格取得"
       ],
       "description": "AWS Certified Data Analytics - Specialty（DAS-C01）試験に合格しましたので、その体験をシェアします。",
+      "slug": "DVA-C02-pass-experience",
       "path": "src/data/blog/_2023/DVA-C02-pass-experience.md",
       "similarity": 0.8
     },
@@ -372,14 +369,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.77
     }
@@ -389,7 +385,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-03-29T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -397,6 +392,7 @@
         "資格取得"
       ],
       "description": "AWS Certified Data Analytics - Specialty（DAS-C01）試験に合格しましたので、その体験をシェアします。",
+      "slug": "DVA-C02-pass-experience",
       "path": "src/data/blog/_2023/DVA-C02-pass-experience.md",
       "similarity": 0.83
     },
@@ -404,7 +400,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -412,6 +407,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 0.81
     },
@@ -419,7 +415,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-09-30T15:57:52.737Z",
       "title": "AWS Certified Security - Specialty（SCS-C02）合格体験記",
-      "slug": "SCS-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -427,6 +422,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Security - Specialty（SCS-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "SCS-C02-pass-experience",
       "path": "src/data/blog/_2024/SCS-C02-pass-experience.md",
       "similarity": 0.81
     },
@@ -434,7 +430,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -442,6 +437,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.8
     },
@@ -449,14 +445,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.76
     }
@@ -466,7 +461,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -474,6 +468,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 0.85
     },
@@ -481,7 +476,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-09-30T15:57:52.737Z",
       "title": "AWS Certified Security - Specialty（SCS-C02）合格体験記",
-      "slug": "SCS-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -489,6 +483,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Security - Specialty（SCS-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "SCS-C02-pass-experience",
       "path": "src/data/blog/_2024/SCS-C02-pass-experience.md",
       "similarity": 0.85
     },
@@ -496,7 +491,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-10-02T15:57:52.737Z",
       "title": "AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記",
-      "slug": "SOA-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -504,6 +498,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified SysOps Administrator - Associate（SOA-C02）試験に無事合格できましたので、その体験を共有します。",
+      "slug": "SOA-C02-pass-experience",
       "path": "src/data/blog/_2023/SOA-C02-pass-experience.md",
       "similarity": 0.83
     },
@@ -511,7 +506,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -519,6 +513,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.8
     },
@@ -526,14 +521,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.72
     }
@@ -543,14 +537,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.94
     },
@@ -558,7 +551,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -566,6 +558,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.92
     },
@@ -573,7 +566,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-04-01T15:57:52.737Z",
       "title": "AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記",
-      "slug": "DAS-C01-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -581,6 +573,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified Data Analytics - Specialty（DAS-C01） に合格しましたので、試験の体験記を共有します。",
+      "slug": "DAS-C01-pass-experience",
       "path": "src/data/blog/_2024/DAS-C01-pass-experience.md",
       "similarity": 0.74
     },
@@ -588,7 +581,6 @@
       "author": "Devkey",
       "pubDatetime": "2023-10-02T15:57:52.737Z",
       "title": "AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記",
-      "slug": "SOA-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -596,6 +588,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified SysOps Administrator - Associate（SOA-C02）試験に無事合格できましたので、その体験を共有します。",
+      "slug": "SOA-C02-pass-experience",
       "path": "src/data/blog/_2023/SOA-C02-pass-experience.md",
       "similarity": 0.72
     },
@@ -603,7 +596,6 @@
       "author": "Devkey",
       "pubDatetime": "2025-03-24T15:57:52.737Z",
       "title": "AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記",
-      "slug": "DOP-C02-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -611,6 +603,7 @@
         "資格取得"
       ],
       "description": "この度、AWS Certified DevOps Engineer - Professional（DOP-C02）試験に無事合格できましたので、その体験をシェアします。",
+      "slug": "DOP-C02-pass-experience",
       "path": "src/data/blog/_2025/DOP-C02-pass-experience.md",
       "similarity": 0.7
     }
@@ -620,7 +613,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】PUBG API の使い方【API Key 作成から】",
-      "slug": "how-to-create-pubg-api-key",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/pubg-apikey.jpg",
       "tags": [
@@ -628,6 +620,7 @@
         "開発（ゲーム関連）"
       ],
       "description": "PUBG（PlayerUnknown's Battlegrounds）のマッチデータなどを分析するためには、公式の開発者APIキーが必要です。ここでは、PUBG APIキー取得手順を紹介します。",
+      "slug": "how-to-create-pubg-api-key",
       "path": "src/data/blog/_2019/how-to-create-pubg-api-key.md",
       "similarity": 0.37
     },
@@ -635,7 +628,6 @@
       "author": "Devkey",
       "pubDatetime": "2020-01-29T21:22:51.127Z",
       "title": "静音リングを使って最強のゲーミングキーボードにカスタマイズする方法",
-      "slug": "corsair-keyboard-customize",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2020/corsair-keyboard-customize.png",
       "tags": [
@@ -645,6 +637,7 @@
       ],
       "category": "Hardware",
       "description": "銀軸キーボードの魅力を最大限に引き出すカスタマイズ方法をご紹介。入力の速さを活かしつつ、デメリットを解決する方法を解説します。",
+      "slug": "corsair-keyboard-customize",
       "path": "src/data/blog/_2020/corsair-keyboard-customize.mdx",
       "similarity": 0.35
     },
@@ -652,7 +645,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -660,6 +652,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.33
     },
@@ -667,7 +660,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
-      "slug": "change-timezone-pubg",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
@@ -675,6 +667,7 @@
         "ゲームライフハック"
       ],
       "description": "PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。",
+      "slug": "change-timezone-pubg",
       "path": "src/data/blog/_2019/change-timezone-pubg.md",
       "similarity": 0.32
     },
@@ -683,7 +676,6 @@
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
       "featured": false,
-      "ogImage": "../../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
         "PUBG",
         "ゲームライフハック"
@@ -699,7 +691,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -707,14 +698,28 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
-      "similarity": 0.2
+      "similarity": 0.26
     },
     {
       "author": "Devkey",
-      "pubDatetime": "2022-12-29T18:51:13.737Z",
-      "title": "【Chrome Extension】111",
-      "slug": "how-to-register-chrome-extension",
+      "pubDatetime": "2024-08-28T19:03:02.737Z",
+      "title": "【Deadlock】日本語化ファイルを公開しました。",
+      "featured": false,
+      "tags": [
+        "AWS",
+        "資格取得"
+      ],
+      "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
+      "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
+      "similarity": 0.24
+    },
+    {
+      "author": "Devkey",
+      "pubDatetime": "2019-12-29T18:51:13.737Z",
+      "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
@@ -722,29 +727,28 @@
         "ゲームライフハック"
       ],
       "description": "PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。",
-      "path": "src/data/blog/_2022/ffmpeg-wasm-extension.md",
-      "similarity": 0.19
+      "slug": "change-timezone-pubg",
+      "path": "src/data/blog/_2019/change-timezone-pubg.md",
+      "similarity": 0.23
     },
     {
       "author": "Devkey",
-      "pubDatetime": "2024-08-28T19:03:02.737Z",
-      "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
+      "pubDatetime": "2019-12-29T18:51:13.737Z",
+      "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
-        "AWS",
-        "資格取得"
+        "PUBG",
+        "ゲームライフハック"
       ],
-      "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
-      "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
-      "similarity": 0.18
+      "description": "PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。",
+      "slug": "change-timezone-pubg",
+      "path": "src/data/blog/_2019/en/change-timezone-pubg.md",
+      "similarity": 0.23
     },
     {
       "author": "Devkey",
       "pubDatetime": "2022-09-29T15:57:52.737Z",
       "title": "AWS Certified Solutions Architect - Associate (SAA-C03) 合格体験記",
-      "slug": "SAA-C03-pass-experience",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -752,25 +756,9 @@
       ],
       "category": "資格取得",
       "description": "先日 AWS Certified Solutions Architect – Associate（SAA-C03）を受験したので、情報共有します。2022年9月に SAA-C02 から SAA-C03 へ試験が切り替わったため、新試験の特徴を共有します。",
+      "slug": "SAA-C03-pass-experience",
       "path": "src/data/blog/_2022/SAA-C03-pass-experience.md",
-      "similarity": 0.16
-    },
-    {
-      "author": "Devkey",
-      "pubDatetime": "2020-01-29T21:22:51.127Z",
-      "title": "静音リングを使って最強のゲーミングキーボードにカスタマイズする方法",
-      "slug": "corsair-keyboard-customize",
-      "featured": false,
-      "ogImage": "../../../assets/images/blog/2020/corsair-keyboard-customize.png",
-      "tags": [
-        "キーボード",
-        "デバイス",
-        "ゲームライフハック"
-      ],
-      "category": "Hardware",
-      "description": "銀軸キーボードの魅力を最大限に引き出すカスタマイズ方法をご紹介。入力の速さを活かしつつ、デメリットを解決する方法を解説します。",
-      "path": "src/data/blog/_2020/corsair-keyboard-customize.mdx",
-      "similarity": 0.13
+      "similarity": 0.21
     }
   ],
   "src/data/blog/_2020/corsair-keyboard-customize.mdx": [
@@ -778,7 +766,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】PUBG API の使い方【API Key 作成から】",
-      "slug": "how-to-create-pubg-api-key",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/pubg-apikey.jpg",
       "tags": [
@@ -786,6 +773,7 @@
         "開発（ゲーム関連）"
       ],
       "description": "PUBG（PlayerUnknown's Battlegrounds）のマッチデータなどを分析するためには、公式の開発者APIキーが必要です。ここでは、PUBG APIキー取得手順を紹介します。",
+      "slug": "how-to-create-pubg-api-key",
       "path": "src/data/blog/_2019/how-to-create-pubg-api-key.md",
       "similarity": 0.52
     },
@@ -793,7 +781,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
-      "slug": "change-timezone-pubg",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
@@ -801,6 +788,7 @@
         "ゲームライフハック"
       ],
       "description": "PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。",
+      "slug": "change-timezone-pubg",
       "path": "src/data/blog/_2019/change-timezone-pubg.md",
       "similarity": 0.49
     },
@@ -809,7 +797,6 @@
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
       "featured": false,
-      "ogImage": "../../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
         "PUBG",
         "ゲームライフハック"
@@ -823,7 +810,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -831,6 +817,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.44
     },
@@ -838,14 +825,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.4
     }
@@ -855,7 +841,6 @@
       "author": "Devkey",
       "pubDatetime": "2020-01-29T21:22:51.127Z",
       "title": "静音リングを使って最強のゲーミングキーボードにカスタマイズする方法",
-      "slug": "corsair-keyboard-customize",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2020/corsair-keyboard-customize.png",
       "tags": [
@@ -865,6 +850,7 @@
       ],
       "category": "Hardware",
       "description": "銀軸キーボードの魅力を最大限に引き出すカスタマイズ方法をご紹介。入力の速さを活かしつつ、デメリットを解決する方法を解説します。",
+      "slug": "corsair-keyboard-customize",
       "path": "src/data/blog/_2020/corsair-keyboard-customize.mdx",
       "similarity": 0.52
     },
@@ -872,7 +858,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
-      "slug": "change-timezone-pubg",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
@@ -880,6 +865,7 @@
         "ゲームライフハック"
       ],
       "description": "PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。",
+      "slug": "change-timezone-pubg",
       "path": "src/data/blog/_2019/change-timezone-pubg.md",
       "similarity": 0.51
     },
@@ -888,7 +874,6 @@
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
       "featured": false,
-      "ogImage": "../../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
         "PUBG",
         "ゲームライフハック"
@@ -902,7 +887,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -910,6 +894,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.39
     },
@@ -917,14 +902,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.37
     }
@@ -935,7 +919,6 @@
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
       "featured": false,
-      "ogImage": "../../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
         "PUBG",
         "ゲームライフハック"
@@ -949,7 +932,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】PUBG API の使い方【API Key 作成から】",
-      "slug": "how-to-create-pubg-api-key",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/pubg-apikey.jpg",
       "tags": [
@@ -957,6 +939,7 @@
         "開発（ゲーム関連）"
       ],
       "description": "PUBG（PlayerUnknown's Battlegrounds）のマッチデータなどを分析するためには、公式の開発者APIキーが必要です。ここでは、PUBG APIキー取得手順を紹介します。",
+      "slug": "how-to-create-pubg-api-key",
       "path": "src/data/blog/_2019/how-to-create-pubg-api-key.md",
       "similarity": 0.51
     },
@@ -964,7 +947,6 @@
       "author": "Devkey",
       "pubDatetime": "2020-01-29T21:22:51.127Z",
       "title": "静音リングを使って最強のゲーミングキーボードにカスタマイズする方法",
-      "slug": "corsair-keyboard-customize",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2020/corsair-keyboard-customize.png",
       "tags": [
@@ -974,6 +956,7 @@
       ],
       "category": "Hardware",
       "description": "銀軸キーボードの魅力を最大限に引き出すカスタマイズ方法をご紹介。入力の速さを活かしつつ、デメリットを解決する方法を解説します。",
+      "slug": "corsair-keyboard-customize",
       "path": "src/data/blog/_2020/corsair-keyboard-customize.mdx",
       "similarity": 0.49
     },
@@ -981,7 +964,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -989,6 +971,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.41
     },
@@ -996,14 +979,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.33
     }
@@ -1013,7 +995,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】",
-      "slug": "change-timezone-pubg",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/tokyo-beijing.jpg",
       "tags": [
@@ -1021,6 +1002,7 @@
         "ゲームライフハック"
       ],
       "description": "PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。",
+      "slug": "change-timezone-pubg",
       "path": "src/data/blog/_2019/change-timezone-pubg.md",
       "similarity": 1
     },
@@ -1028,7 +1010,6 @@
       "author": "Devkey",
       "pubDatetime": "2019-12-29T18:51:13.737Z",
       "title": "【PUBG】PUBG API の使い方【API Key 作成から】",
-      "slug": "how-to-create-pubg-api-key",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2019/pubg-apikey.jpg",
       "tags": [
@@ -1036,6 +1017,7 @@
         "開発（ゲーム関連）"
       ],
       "description": "PUBG（PlayerUnknown's Battlegrounds）のマッチデータなどを分析するためには、公式の開発者APIキーが必要です。ここでは、PUBG APIキー取得手順を紹介します。",
+      "slug": "how-to-create-pubg-api-key",
       "path": "src/data/blog/_2019/how-to-create-pubg-api-key.md",
       "similarity": 0.51
     },
@@ -1043,7 +1025,6 @@
       "author": "Devkey",
       "pubDatetime": "2020-01-29T21:22:51.127Z",
       "title": "静音リングを使って最強のゲーミングキーボードにカスタマイズする方法",
-      "slug": "corsair-keyboard-customize",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2020/corsair-keyboard-customize.png",
       "tags": [
@@ -1053,6 +1034,7 @@
       ],
       "category": "Hardware",
       "description": "銀軸キーボードの魅力を最大限に引き出すカスタマイズ方法をご紹介。入力の速さを活かしつつ、デメリットを解決する方法を解説します。",
+      "slug": "corsair-keyboard-customize",
       "path": "src/data/blog/_2020/corsair-keyboard-customize.mdx",
       "similarity": 0.49
     },
@@ -1060,7 +1042,6 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-26T19:03:02.737Z",
       "title": "【Deadlock】日本語設定ファイルの作成方法",
-      "slug": "localizing-deadlock-into-japanese",
       "featured": false,
       "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
@@ -1068,6 +1049,7 @@
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "localizing-deadlock-into-japanese",
       "path": "src/data/blog/_2024/localizing-deadlock-into-japanese.md",
       "similarity": 0.41
     },
@@ -1075,14 +1057,13 @@
       "author": "Devkey",
       "pubDatetime": "2024-08-28T19:03:02.737Z",
       "title": "【Deadlock】日本語化ファイルを公開しました。",
-      "slug": "launching-deadlock-japanese-website",
       "featured": false,
-      "ogImage": "../../../assets/images/blog/2021/AWS.JPG",
       "tags": [
         "AWS",
         "資格取得"
       ],
       "description": "AWSの資格試験に合格しました。GWの思い出として、当時の振り返りと、やったこと、反省点兼ねて書き残してみます。生成AIとかも使ってみた振り返りも。",
+      "slug": "launching-deadlock-japanese-website",
       "path": "src/data/blog/_2024/launching-deadlock-japanese-website.md",
       "similarity": 0.33
     }

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -39,36 +39,36 @@ const related = items.slice(0, maxItems);
       </h2>
       <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2">
         {related.map(post => (
-          <li class="overflow-hidden rounded border border-border">
+          <li class="my-6">
             <a href={`/posts/${post.slug}/`} class="block hover:opacity-90">
-              <div class="relative">
-                {post.tags && post.tags.length > 0 && (
-                  <ul class="absolute top-2 left-2 z-10 flex flex-wrap gap-1">
-                    {post.tags.map((tag: string) => (
-                      <Tag tag={slugifyStr(tag)} tagName={tag} size="sm" />
-                    ))}
-                  </ul>
-                )}
-                <img
-                  src={post.ogImage}
-                  alt={post.title}
-                  class="aspect-video w-full object-cover"
-                  loading="lazy"
-                />
-              </div>
-              <div class="p-3">
-                <h3 class="text-lg font-medium decoration-dashed hover:underline">
-                  {post.title}
-                </h3>
-                <div class="my-1 flex items-center gap-2 text-sm">
-                  <Datetime
-                    pubDatetime={new Date(post.pubDatetime)}
-                    modDatetime={null}
-                    timezone={SITE.timezone}
+              <div class="overflow-hidden rounded border border-border">
+                <div class="relative">
+                  {post.tags && post.tags.length > 0 && (
+                    <ul class="absolute top-2 left-2 z-10 flex flex-wrap gap-1">
+                      {post.tags.map((tag: string) => (
+                        <Tag tag={slugifyStr(tag)} tagName={tag} size="sm" />
+                      ))}
+                    </ul>
+                  )}
+                  <img
+                    src={post.ogImage}
+                    alt={post.title}
+                    class="aspect-video w-full object-cover"
+                    loading="lazy"
                   />
                 </div>
-                <p class="text-sm">{post.description}</p>
               </div>
+              <h3 class="mt-3 text-lg font-medium decoration-dashed hover:underline">
+                {post.title}
+              </h3>
+              <div class="my-1 flex items-center gap-2 text-sm">
+                <Datetime
+                  pubDatetime={new Date(post.pubDatetime)}
+                  modDatetime={null}
+                  timezone={SITE.timezone}
+                />
+              </div>
+              <p>{post.description}</p>
             </a>
           </li>
         ))}

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -58,17 +58,6 @@ const related = items.slice(0, maxItems);
                   />
                 </div>
               </div>
-              <h3 class="mt-3 text-lg font-medium decoration-dashed hover:underline">
-                {post.title}
-              </h3>
-              <div class="my-1 flex items-center gap-2 text-sm">
-                <Datetime
-                  pubDatetime={new Date(post.pubDatetime)}
-                  modDatetime={null}
-                  timezone={SITE.timezone}
-                />
-              </div>
-              <p>{post.description}</p>
             </a>
           </li>
         ))}

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -1,9 +1,8 @@
 ---
 import Tag from "./Tag.astro";
-import Datetime from "./Datetime.astro";
 import { slugifyStr } from "@/utils/slugify";
-import { SITE } from "@/config";
 import rawSimilarities from "../assets/similarities.json";
+import path from "node:path";
 
 interface RelatedPost {
   author: string;
@@ -19,6 +18,20 @@ interface RelatedPost {
 }
 
 const similarities = rawSimilarities as Record<string, RelatedPost[]>;
+
+const BASE_RAW_URL =
+  "https://raw.githubusercontent.com/NPJigaK/me/refs/heads/ads/";
+const BASE_BLOG_URL = "http://localhost:4321/posts/";
+
+function getImageUrl(post: RelatedPost) {
+  if(!post.ogImage){
+    return BASE_BLOG_URL + post.slug + "/index.png";
+  }
+  const normalizedPath = path.normalize(
+    path.join(path.dirname(post.path), post.ogImage)
+  );
+  return BASE_RAW_URL + normalizedPath;
+}
 
 export interface Props {
   filePath: string | undefined;
@@ -51,7 +64,7 @@ const related = items.slice(0, maxItems);
                     </ul>
                   )}
                   <img
-                    src={post.ogImage}
+                    src={getImageUrl(post)}
                     alt={post.title}
                     class="aspect-video w-full object-cover"
                     loading="lazy"

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -37,32 +37,39 @@ const related = items.slice(0, maxItems);
       <h2 id="related-title" class="text-2xl font-semibold tracking-wide">
         Related Posts
       </h2>
-      <ul>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2">
         {related.map(post => (
-          <li class="my-6">
-            <a
-              href={`/posts/${post.slug}/`}
-              class="inline-block text-lg font-medium text-accent decoration-dashed underline-offset-4 hover:underline focus-visible:no-underline focus-visible:underline-offset-0"
-            >
-              <h3 class="text-lg font-medium decoration-dashed hover:underline">
-                {post.title}
-              </h3>
+          <li class="overflow-hidden rounded border border-border">
+            <a href={`/posts/${post.slug}/`} class="block hover:opacity-90">
+              <div class="relative">
+                {post.tags && post.tags.length > 0 && (
+                  <ul class="absolute top-2 left-2 z-10 flex flex-wrap gap-1">
+                    {post.tags.map((tag: string) => (
+                      <Tag tag={slugifyStr(tag)} tagName={tag} size="sm" />
+                    ))}
+                  </ul>
+                )}
+                <img
+                  src={post.ogImage}
+                  alt={post.title}
+                  class="aspect-video w-full object-cover"
+                  loading="lazy"
+                />
+              </div>
+              <div class="p-3">
+                <h3 class="text-lg font-medium decoration-dashed hover:underline">
+                  {post.title}
+                </h3>
+                <div class="my-1 flex items-center gap-2 text-sm">
+                  <Datetime
+                    pubDatetime={new Date(post.pubDatetime)}
+                    modDatetime={null}
+                    timezone={SITE.timezone}
+                  />
+                </div>
+                <p class="text-sm">{post.description}</p>
+              </div>
             </a>
-            <div class="flex items-center gap-2">
-              <Datetime
-                pubDatetime={new Date(post.pubDatetime)}
-                modDatetime={null}
-                timezone={SITE.timezone}
-              />
-            </div>
-            <p>{post.description}</p>
-            {post.tags && post.tags.length > 0 && (
-              <ul class="mt-2 flex flex-wrap gap-1">
-                {post.tags.map((tag: string) => (
-                  <Tag tag={slugifyStr(tag)} tagName={tag} size="sm" />
-                ))}
-              </ul>
-            )}
           </li>
         ))}
       </ul>

--- a/src/data/blog/_2019/change-timezone-pubg.md
+++ b/src/data/blog/_2019/change-timezone-pubg.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2019-12-29T18:51:13.737Z
 title: 【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】
-slug: change-timezone-pubg
 featured: false
 ogImage: ../../../assets/images/blog/2019/tokyo-beijing.jpg
 tags:

--- a/src/data/blog/_2019/en/change-timezone-pubg.md
+++ b/src/data/blog/_2019/en/change-timezone-pubg.md
@@ -3,7 +3,6 @@ author: Devkey
 pubDatetime: 2019-12-29T18:51:13.737Z
 title: 【PUBG】タイムゾーンを1クリックで変更させる方法【東京⇔北京】
 featured: false
-ogImage: ../../../../assets/images/blog/2019/tokyo-beijing.jpg
 tags:
   - PUBG
   - ゲームライフハック

--- a/src/data/blog/_2019/how-to-create-pubg-api-key.md
+++ b/src/data/blog/_2019/how-to-create-pubg-api-key.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2019-12-29T18:51:13.737Z
 title: 【PUBG】PUBG API の使い方【API Key 作成から】
-slug: how-to-create-pubg-api-key
 featured: false
 ogImage: ../../../assets/images/blog/2019/pubg-apikey.jpg
 tags:

--- a/src/data/blog/_2020/corsair-keyboard-customize.mdx
+++ b/src/data/blog/_2020/corsair-keyboard-customize.mdx
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2020-01-29T21:22:51.127Z
 title: 静音リングを使って最強のゲーミングキーボードにカスタマイズする方法
-slug: corsair-keyboard-customize
 featured: false
 ogImage: ../../../assets/images/blog/2020/corsair-keyboard-customize.png
 tags:

--- a/src/data/blog/_2021/how-to-register-chrome-extension.md
+++ b/src/data/blog/_2021/how-to-register-chrome-extension.md
@@ -2,11 +2,20 @@
 author: Devkey
 pubDatetime: 2021-12-29T18:51:13.737Z
 title: 【Chrome Extension】111
-slug: how-to-register-chrome-extension
 featured: false
-ogImage: ../../../assets/images/blog/2019/tokyo-beijing.jpg
 tags:
   - PUBG
   - ゲームライフハック
 description: PUBGで8×8マップを遊びたいのにマッチしない？そんなときは、サーバーリージョンを変更してみよう。1クリックで切り替えられる便利な方法を紹介します。
 ---
+
+
+
+
+aaaaaaaaaaaaa
+
+
+
+
+
+# owari

--- a/src/data/blog/_2022/SAA-C03-pass-experience.md
+++ b/src/data/blog/_2022/SAA-C03-pass-experience.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2022-09-29T15:57:52.737Z
 title: AWS Certified Solutions Architect - Associate (SAA-C03) 合格体験記
-slug: SAA-C03-pass-experience
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:

--- a/src/data/blog/_2022/ffmpeg-wasm-extension.md
+++ b/src/data/blog/_2022/ffmpeg-wasm-extension.md
@@ -2,9 +2,7 @@
 author: Devkey
 pubDatetime: 2022-12-29T18:51:13.737Z
 title: 【Chrome Extension】111
-slug: how-to-register-chrome-extension
 featured: false
-ogImage: ../../../assets/images/blog/2019/tokyo-beijing.jpg
 tags:
   - PUBG
   - ゲームライフハック

--- a/src/data/blog/_2023/DVA-C02-pass-experience.md
+++ b/src/data/blog/_2023/DVA-C02-pass-experience.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2023-03-29T15:57:52.737Z
 title: AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記
-slug: SAA-C03-pass-experience
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:

--- a/src/data/blog/_2023/SOA-C02-pass-experience.md
+++ b/src/data/blog/_2023/SOA-C02-pass-experience.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2023-10-02T15:57:52.737Z
 title: AWS Certified SysOps Administrator - Associate（SOA-C02）合格体験記
-slug: SOA-C02-pass-experience
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:

--- a/src/data/blog/_2024/DAS-C01-pass-experience.md
+++ b/src/data/blog/_2024/DAS-C01-pass-experience.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2024-04-01T15:57:52.737Z
 title: AWS Certified Data Analytics - Specialty（DAS-C01）合格体験記
-slug: DAS-C01-pass-experience
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:

--- a/src/data/blog/_2024/SCS-C02-pass-experience.md
+++ b/src/data/blog/_2024/SCS-C02-pass-experience.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2024-09-30T15:57:52.737Z
 title: AWS Certified Security - Specialty（SCS-C02）合格体験記
-slug: SCS-C02-pass-experience
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:

--- a/src/data/blog/_2024/launching-deadlock-japanese-website.md
+++ b/src/data/blog/_2024/launching-deadlock-japanese-website.md
@@ -2,9 +2,7 @@
 author: Devkey
 pubDatetime: 2024-08-28T19:03:02.737Z
 title: 【Deadlock】日本語化ファイルを公開しました。
-slug: launching-deadlock-japanese-website
 featured: false
-ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:
   - AWS
   - 資格取得

--- a/src/data/blog/_2024/localizing-deadlock-into-japanese.md
+++ b/src/data/blog/_2024/localizing-deadlock-into-japanese.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2024-08-26T19:03:02.737Z
 title: 【Deadlock】日本語設定ファイルの作成方法
-slug: localizing-deadlock-into-japanese
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:

--- a/src/data/blog/_2025/DOP-C02-pass-experience.md
+++ b/src/data/blog/_2025/DOP-C02-pass-experience.md
@@ -2,7 +2,6 @@
 author: Devkey
 pubDatetime: 2025-03-24T15:57:52.737Z
 title: AWS Certified DevOps Engineer - Professional（DOP-C02）合格体験記
-slug: DOP-C02-pass-experience
 featured: false
 ogImage: ../../../assets/images/blog/2021/AWS.JPG
 tags:


### PR DESCRIPTION
## Summary
- display related posts in a two-column grid
- overlay tags on the og image
- show og image and post details inside a bordered box

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685e608d6160832a981e288ce280eed1