### PR TITLE
Fix OG image font for Japanese

### DIFF
--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -62,14 +62,14 @@ async function loadGoogleFonts(
 > {
   const fontsConfig = [
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "Noto Sans JP",
+      font: "Noto+Sans+JP",
       weight: 400,
       style: "normal",
     },
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "Noto Sans JP",
+      font: "Noto+Sans+JP",
       weight: 700,
       style: "bold",
     },


### PR DESCRIPTION
## Summary
- update og image font config to use Noto Sans JP

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685f978f32c8832aa97c22d0e256a177