### PR TITLE
Align ad card with related posts

### DIFF
--- a/src/components/AdSense.astro
+++ b/src/components/AdSense.astro
@@ -3,16 +3,17 @@ import { PUBLIC_GOOGLE_ADSENSE_CLIENT } from "astro:env/client";
 
 export interface Props {
   slot?: string;
+  class?: string;
 }
 
-const { slot = "" } = Astro.props as Props;
+const { slot = "", class: className = "" } = Astro.props as Props;
 ---
 
 {
   PUBLIC_GOOGLE_ADSENSE_CLIENT && slot && (
     <>
       <ins
-        class="adsbygoogle"
+        class:list={["adsbygoogle", className]}
         style="display:block"
         data-ad-client={PUBLIC_GOOGLE_ADSENSE_CLIENT}
         data-ad-slot={slot}

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -76,7 +76,9 @@ const ADS_SLOT_ID = "2943797848";
           </li>
         ))}
         <li class="my-6">
-          <AdSense slot={ADS_SLOT_ID} />
+          <div class="relative aspect-video overflow-hidden rounded border border-border">
+            <AdSense slot={ADS_SLOT_ID} class="h-full w-full" />
+          </div>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- allow custom classes on `AdSense` component
- wrap ad in `Related` with a container matching related post layout

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6862bf84d894832aaec2560029e2e0d1