### PR TITLE
Add width and height props to AdSense

### DIFF
--- a/src/components/AdSense.astro
+++ b/src/components/AdSense.astro
@@ -3,17 +3,27 @@ import { PUBLIC_GOOGLE_ADSENSE_CLIENT } from "astro:env/client";
 
 export interface Props {
   slot?: string;
+  class?: string;
+  width?: string;
+  height?: string;
 }
 
-const { slot = "" } = Astro.props as Props;
+const {
+  slot = "",
+  class: className = "",
+  width = "",
+  height = "",
+} = Astro.props as Props;
 ---
 
 {
   PUBLIC_GOOGLE_ADSENSE_CLIENT && slot && (
     <>
       <ins
-        class="adsbygoogle"
-        style="display:block"
+        class:list={["adsbygoogle", className]}
+        style={`display:block${width ? `;width:${width}` : ""}${
+          height ? `;height:${height}` : ""
+        }`}
         data-ad-client={PUBLIC_GOOGLE_ADSENSE_CLIENT}
         data-ad-slot={slot}
         data-ad-format="auto"

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -76,7 +76,14 @@ const ADS_SLOT_ID = "2943797848";
           </li>
         ))}
         <li class="my-6">
-          <AdSense slot={ADS_SLOT_ID} />
+          <div class="relative aspect-video overflow-hidden rounded border border-border">
+            <AdSense
+              slot={ADS_SLOT_ID}
+              class="h-full w-full"
+              width="100%"
+              height="100%"
+            />
+          </div>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- allow specifying ad width/height in `AdSense`
- pass 100% width/height in `Related` ads

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6862bf84d894832aaec2560029e2e0d1