### PR TITLE
fix adsense rerun issue

### DIFF
--- a/src/components/AdSense.astro
+++ b/src/components/AdSense.astro
@@ -27,7 +27,7 @@ const {
         data-ad-client={PUBLIC_GOOGLE_ADSENSE_CLIENT}
         data-ad-slot={slot}
       />
-      <script is:inline>
+      <script is:inline data-astro-rerun>
         (adsbygoogle = window.adsbygoogle || []).push({});
       </script>
     </>


### PR DESCRIPTION
## Summary
- ensure AdSense scripts run on page navigation

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686360c5bfc0832a8f2e73ad06bf1fc0