### PR TITLE
Fix dark mode flash before AdSense loads

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -119,6 +119,8 @@ const structuredData = {
 
     <meta name="theme-color" content="" />
 
+    <script is:inline src="/toggle-theme.js"></script>
+
     {
       // If PUBLIC_GOOGLE_SITE_VERIFICATION is set in the environment variable,
       // include google-site-verification tag in the heading
@@ -143,8 +145,6 @@ const structuredData = {
     }
 
     <ClientRouter />
-
-    <script is:inline src="/toggle-theme.js"></script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## Summary
- ensure the theme script runs before the AdSense script

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6864c5c1957c832a9bf2f378b031e4e4