### PR TITLE
Add favicon to post OG template

### DIFF
--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -37,15 +37,34 @@ export default async post =>
               style: {
                 display: "flex",
                 justifyContent: "space-between",
+                alignItems: "center",
                 fontSize: 32,
               },
               children: [
                 // { type: "span", props: { children: post.data.author } },
                 {
-                  type: "span",
+                  type: "div",
                   props: {
-                    style: { fontWeight: "bold" },
-                    children: SITE.title,
+                    style: { display: "flex", alignItems: "center" },
+                    children: [
+                      {
+                        type: "img",
+                        props: {
+                          src: "https://devkey.jp/favicon.svg",
+                          width: 32,
+                          height: 32,
+                          style: { marginRight: 8 },
+                          alt: "favicon",
+                        },
+                      },
+                      {
+                        type: "span",
+                        props: {
+                          style: { fontWeight: "bold" },
+                          children: SITE.title,
+                        },
+                      },
+                    ],
                   },
                 },
               ],


### PR DESCRIPTION
## Summary
- include the site favicon next to the title in the post OG image template

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build` *(fails to fetch remote favicon but build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68662a29f270832abaec64fac01fed55